### PR TITLE
Disable lineLimitReader when handle BDAT data

### DIFF
--- a/lengthlimit_reader.go
+++ b/lengthlimit_reader.go
@@ -19,7 +19,7 @@ type lineLimitReader struct {
 }
 
 func (r *lineLimitReader) Read(b []byte) (int, error) {
-	if r.curLineLength > r.LineLimit {
+	if r.curLineLength > r.LineLimit && r.LineLimit > 0 {
 		return 0, ErrTooLongLine
 	}
 


### PR DESCRIPTION
References: https://github.com/emersion/go-smtp/issues/81#issuecomment-801659120